### PR TITLE
handle messages with the 'silent' priority

### DIFF
--- a/logcatcolor/column.py
+++ b/logcatcolor/column.py
@@ -106,7 +106,8 @@ class PriorityColumn(Column):
         "I": Fore.BLACK + Back.GREEN,
         "W": Fore.BLACK + Back.YELLOW,
         "E": Fore.BLACK + Back.RED,
-        "F": Fore.BLACK + Back.RED
+        "F": Fore.BLACK + Back.RED,
+        "S": Fore.BLACK + Back.WHITE
     }
 
     def __init__(self, layout):


### PR DESCRIPTION
The [Android log.h header file](https://android.googlesource.com/platform/system/core/+/master/include/android/log.h), which native apps can use to write to Android's log, defines a "silent" priority for log messages. Consumers presumably shouldn't use this priority, but if they do, then Android non-silently writes them to the log with the "S" priority abbreviation, which crashes logcat-color!

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/logcatcolor/reader.py", line 53, in found_terminator
    self.process_line(line)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/logcatcolor/reader.py", line 118, in process_line
    self.layout_line(line)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/logcatcolor/reader.py", line 131, in layout_line
    result = self.layout.layout_data(self.format.data)
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/logcatcolor/layout.py", line 51, in layout_data
    formatted.write(column.format(data[column.NAME]))
  File "/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/logcatcolor/column.py", line 120, in format
    return self.formats[priority]
KeyError: 'S'
```

Here's the simple fix: define colors for the "S" priority abbreviation. I wasn't sure which colors to use, so I just chose the reverse of the colors for the "V" priority.
